### PR TITLE
docs: trim trailing dots in README intro

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # observability-ghactions
 
-This is a Sample WDIO Project to demonstrate how Test Observability works. Try it out and explore...
+This is a Sample WDIO Project to demonstrate how Test Observability works. Try it out and explore.
 
 ## Execute Suite - WDIO - Mocha & Cucumber
 1. Install nvm and Switch to nvm v16.10.0 - ```nvm use v16.10.0```


### PR DESCRIPTION
## Summary
- Trivial README copy fix: trims `....` → `.` in the intro line.

## Purpose
Sample PR to exercise the webhook → Jenkins (via ngrok) → TRA quality-gate → GitHub PR-check pipeline end-to-end. Not intended to alter behavior.

## Test plan
- [ ] Webhook fires Jenkins job on PR open
- [ ] Jenkins runs tests locally on commit `4478866`
- [ ] Results land in Test Reporting & Analytics
- [ ] Quality gates report status back as a PR check

🤖 Generated with [Claude Code](https://claude.com/claude-code)