### PR TITLE
fix(web-regression): eliminate new failures from latest TRA run

### DIFF
--- a/pageobjects/bstack-demo/signIn.app.error.page.js
+++ b/pageobjects/bstack-demo/signIn.app.error.page.js
@@ -26,7 +26,9 @@ class SignInAppErrorPage extends Page {
      * e.g. to login using username and password
      */
     async login (username, password) {
+        await this.userNameInput.waitForExist({ timeout: 15000 });
         await this.userNameInput.setValue(username);
+        await this.passwordInput.waitForExist({ timeout: 15000 });
         await this.passwordInput.setValue(password);
         await this.loginBtn.click();
         await browser.pause(10000);

--- a/stepdefinitions/signInPageSteps.js
+++ b/stepdefinitions/signInPageSteps.js
@@ -95,9 +95,9 @@ Given(/^Verify all SignInPage UI logging - ([0-9]+)$/, {timeout: 5*60*1000}, asy
     await new Promise(r => setTimeout(r, sleep_time));
     await signInAppErrorPage.open();
     await new Promise(r => setTimeout(r, sleep_time));
-    signInAppErrorPage.login("demouser\t", "testingisfun99\t")
+    await signInAppErrorPage.login("demouser\t", "testingisfun99\t");
     await new Promise(r => setTimeout(r, sleep_time));
-    signInAppErrorPage.login("demouser\t", "testingisfun99\t")
+    await signInAppErrorPage.login("demouser\t", "testingisfun99\t");
     await new Promise(r => setTimeout(r, sleep_time));
     await signInAppErrorPage.openErrorPage();
 });

--- a/wdio-cucumber-bs-regression.conf.js
+++ b/wdio-cucumber-bs-regression.conf.js
@@ -231,7 +231,8 @@ exports.config = {
         failFast: false, // Fail on first step, useful for debugging
         format: ['pretty'],
         snippets: true, // Show pending step suggestions
-        ignoreUndefinedDefinitions: false // Treat undefined definitions as warnings
+        ignoreUndefinedDefinitions: false, // Treat undefined definitions as warnings
+        timeout: 60000 // BrowserStack cross-browser page loads can exceed Cucumber's 10s default
     },
     //
     // =====


### PR DESCRIPTION
## Summary

Eliminates the 3 tests flagged as **New failures** in the latest Web Regression TRA run (`build_id=l7xtymrbmk13mpf5fysnopnnirbiudkmlzugmmtb`, build #10 of project "WDIO Example"). Each had a distinct root cause; this PR fixes all three with surgical edits.

## Failures addressed

| # | Scenario | Error | Fix |
|---|---|---|---|
| 1 | `Verify Logging - Browserstack Logo Text - Fail` | `Can't call elementSendKeys on "#password input" — element wasn't found` | `signIn.app.error.page.js`: `waitForExist` on inputs before `setValue`. `signInPageSteps.js`: `await` the previously-unawaited `signInAppErrorPage.login()` calls in the `Verify all SignInPage UI logging` step (so the race against page render is removed and promise rejections actually propagate). |
| 2 | `Verify Sign In Button` | `function timed out, ensure the promise resolves within 10000 milliseconds` | `wdio-cucumber-bs-regression.conf.js`: raise Cucumber step `timeout` from the 10s default to 60s — BrowserStack cross-browser page loads can routinely exceed 10s. |
| 3 | `Verify Sign In Button Text` | same as #2 (ran in the same BrowserStack session) | covered by the same timeout bump |

## Diagnosis source

TRA API: `GET /ext/v1/builds/l7xtymrbmk13mpf5fysnopnnirbiudkmlzugmmtb/testRuns?is_new_failure=true` against the `WDIO Example` project (project_id `329740`). 3 tests returned; each failure's stack and selector was read from `details.retries[0].logs.TEST_FAILURE`.

## Test plan

- [ ] Trigger the Web Regression workflow (manual dispatch on this branch or via `.github/workflows/regression.yml`).
- [ ] Confirm in TRA that the next Web Regression build has **0 new failures** for these 3 scenarios.
- [ ] Spot-check that `Verify Sign In Button` and `Verify Sign In Button Text` pass.
- [ ] Spot-check that `Verify Logging - Browserstack Logo Text - Fail` still fails on its intended logo-text assertion (not on the password element race).

🤖 Generated with [Claude Code](https://claude.com/claude-code)